### PR TITLE
design: 블랙리스트 관리 페이지 추가 완료

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import LandingPage from "@/features/land/pages/LandingPage";
 import SignupPage from "@/features/auth/signup/pages/SignupPage";
 import LoginPage from "@/features/auth/login/pages/LoginPage";
 import ApplicationListPage from "@/features/admin/pages/ApplicationListPage";
+import BlacklistPage from "@/features/admin/pages/BlacklistPage";
 import CompetitionPage from "@/features/competition/pages/CompetitionPage";
 import HistoryPage from "@/features/history/pages/HistoryPage";
 import ContactPage from "@/features/contact/pages/ContactPage";
@@ -136,6 +137,10 @@ export default function App() {
           <Route
             path="/admin/applications"
             element={<ApplicationListPage />}
+          />
+          <Route
+            path="/admin/blacklist"
+            element={<BlacklistPage />}
           />
         </Routes>
       </AnimatePresence>

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -40,7 +40,12 @@ export default function PageHeader() {
     { label: "대회", to: "/competition" },
     { label: "연혁", to: "/history" },
     { label: "문의", to: "/contact" },
-    ...(isAdmin ? [{ label: "신청 관리", to: "/admin/applications" }] : []),
+    ...(isAdmin
+      ? [
+          { label: "신청 관리", to: "/admin/applications" },
+          { label: "블랙리스트", to: "/admin/blacklist" },
+        ]
+      : []),
   ];
 
   return (

--- a/src/features/admin/components/AdminSubNav.tsx
+++ b/src/features/admin/components/AdminSubNav.tsx
@@ -1,0 +1,42 @@
+import { Link, useLocation } from "react-router-dom";
+import { Users, ShieldAlert } from "lucide-react";
+
+export default function AdminSubNav() {
+  const { pathname } = useLocation();
+
+  const tabs = [
+    {
+      label: "신청 관리",
+      to: "/admin/applications",
+      icon: Users,
+    },
+    {
+      label: "블랙리스트 관리",
+      to: "/admin/blacklist",
+      icon: ShieldAlert,
+    },
+  ];
+
+  return (
+    <div className="flex items-center gap-2 mb-8 border-b border-neutral-200 pb-3">
+      {tabs.map((tab) => {
+        const Icon = tab.icon;
+        const isActive = pathname === tab.to;
+        return (
+          <Link
+            key={tab.to}
+            to={tab.to}
+            className={`flex items-center gap-2 px-4 py-2 text-sm font-bold transition-all border ${
+              isActive
+                ? "bg-black text-white border-black shadow-sm"
+                : "bg-white text-neutral-600 border-neutral-200 hover:border-neutral-400 hover:text-black"
+            }`}
+          >
+            <Icon size={16} className={isActive ? "text-red-400" : "text-neutral-400"} />
+            {tab.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/admin/components/ApplicationDetailModal.tsx
+++ b/src/features/admin/components/ApplicationDetailModal.tsx
@@ -1,17 +1,17 @@
 import { useState, useEffect } from "react";
-import { type ApplicantResponseDto } from "@/services/types";
+import { type ApplicantResponseDto, type PassStatus } from "@/services/types";
 import { motion } from "framer-motion";
 import { ChevronDown } from "lucide-react";
 
 const CLASS_LEVELS = [
-  { value: "", label: "미정" },
+  { value: "", label: "미배정" },
   { value: "SEED", label: "Seed" },
   { value: "BRANCH", label: "Branch" },
   { value: "TREE", label: "Tree" },
 ] as const;
 
 function normalizeClassLevel(raw: string | null | undefined): string {
-  if (!raw || raw === "미정") return "";
+  if (!raw || raw === "미정" || raw === "미배정") return "";
   const upper = raw.toUpperCase();
   if (["SEED", "BRANCH", "TREE"].includes(upper)) return upper;
   const map: Record<string, string> = { Seed: "SEED", Branch: "BRANCH", Tree: "TREE" };
@@ -21,7 +21,7 @@ function normalizeClassLevel(raw: string | null | undefined): string {
 interface Props {
   app: ApplicantResponseDto;
   onClose: () => void;
-  onUpdateStatus: (isApprove: boolean) => void;
+  onUpdateStatus: (status: PassStatus) => void;
   onUpdateClassLevel: (classLevel: string | null) => void;
 }
 
@@ -36,17 +36,13 @@ export default function ApplicationDetailModal({
     isLoading: true,
   });
   const [selectedLevel, setSelectedLevel] = useState<string>(normalizeClassLevel(app.classLevel));
-  const [selectedStatus, setSelectedStatus] = useState<"PENDING" | "ACCEPTED" | "REJECTED">(
-    app.isApprove === true ? "ACCEPTED" : app.isApprove === false ? "REJECTED" : "PENDING"
-  );
+  const [selectedStatus, setSelectedStatus] = useState<PassStatus>(app.passStatus || "PENDING");
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
-    setDetail((prev) => ({ ...prev, isApprove: app.isApprove }));
-    setSelectedStatus(
-      app.isApprove === true ? "ACCEPTED" : app.isApprove === false ? "REJECTED" : "PENDING"
-    );
-  }, [app.isApprove]);
+    setDetail((prev) => ({ ...prev, passStatus: app.passStatus }));
+    setSelectedStatus(app.passStatus || "PENDING");
+  }, [app.passStatus]);
 
   useEffect(() => {
     const fetchDetail = async () => {
@@ -56,13 +52,7 @@ export default function ApplicationDetailModal({
         );
         setDetail({ ...fullData, isLoading: false });
         setSelectedLevel(normalizeClassLevel(fullData.classLevel));
-        setSelectedStatus(
-          fullData.isApprove === true
-            ? "ACCEPTED"
-            : fullData.isApprove === false
-              ? "REJECTED"
-              : "PENDING"
-        );
+        setSelectedStatus(fullData.passStatus || "PENDING");
       } catch (e) {
         console.error("Failed to fetch detail", e);
         setDetail((prev) => ({ ...prev, isLoading: false }));
@@ -82,14 +72,8 @@ export default function ApplicationDetailModal({
         await onUpdateClassLevel(normLevel);
       }
 
-      const initialStatus =
-        detail.isApprove === true ? "ACCEPTED" : detail.isApprove === false ? "REJECTED" : "PENDING";
-      if (selectedStatus !== initialStatus) {
-        if (selectedStatus === "ACCEPTED") {
-          await onUpdateStatus(true);
-        } else if (selectedStatus === "REJECTED") {
-          await onUpdateStatus(false);
-        }
+      if (selectedStatus !== detail.passStatus) {
+        await onUpdateStatus(selectedStatus);
       }
     } catch (e) {
       console.error("Failed to save changes", e);
@@ -100,11 +84,11 @@ export default function ApplicationDetailModal({
   };
 
   const statusLabel =
-    detail.isApprove === true ? "합격" : detail.isApprove === false ? "불합격" : "대기중";
+    detail.passStatus === "APPROVED" ? "합격" : detail.passStatus === "REJECTED" ? "불합격" : "대기중";
   const statusStyle =
-    detail.isApprove === true
+    detail.passStatus === "APPROVED"
       ? "border-green-400 text-green-700 bg-green-50"
-      : detail.isApprove === false
+      : detail.passStatus === "REJECTED"
         ? "border-red-300 text-red-600 bg-red-50"
         : "border-neutral-300 text-neutral-500";
 
@@ -223,12 +207,12 @@ export default function ApplicationDetailModal({
                 <select
                   value={selectedStatus}
                   onChange={(e) =>
-                    setSelectedStatus(e.target.value as "PENDING" | "ACCEPTED" | "REJECTED")
+                    setSelectedStatus(e.target.value as PassStatus)
                   }
                   className="w-full appearance-none border border-neutral-300 bg-white px-3.5 py-2 pr-8 text-xs font-bold text-neutral-900 outline-none focus:border-black transition-colors"
                 >
                   <option value="PENDING">미정 (대기중)</option>
-                  <option value="ACCEPTED">합격</option>
+                  <option value="APPROVED">합격</option>
                   <option value="REJECTED">불합격</option>
                 </select>
                 <ChevronDown

--- a/src/features/admin/components/ApplicationDetailModal.tsx
+++ b/src/features/admin/components/ApplicationDetailModal.tsx
@@ -36,9 +36,16 @@ export default function ApplicationDetailModal({
     isLoading: true,
   });
   const [selectedLevel, setSelectedLevel] = useState<string>(normalizeClassLevel(app.classLevel));
+  const [selectedStatus, setSelectedStatus] = useState<"PENDING" | "ACCEPTED" | "REJECTED">(
+    app.isApprove === true ? "ACCEPTED" : app.isApprove === false ? "REJECTED" : "PENDING"
+  );
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     setDetail((prev) => ({ ...prev, isApprove: app.isApprove }));
+    setSelectedStatus(
+      app.isApprove === true ? "ACCEPTED" : app.isApprove === false ? "REJECTED" : "PENDING"
+    );
   }, [app.isApprove]);
 
   useEffect(() => {
@@ -49,6 +56,13 @@ export default function ApplicationDetailModal({
         );
         setDetail({ ...fullData, isLoading: false });
         setSelectedLevel(normalizeClassLevel(fullData.classLevel));
+        setSelectedStatus(
+          fullData.isApprove === true
+            ? "ACCEPTED"
+            : fullData.isApprove === false
+              ? "REJECTED"
+              : "PENDING"
+        );
       } catch (e) {
         console.error("Failed to fetch detail", e);
         setDetail((prev) => ({ ...prev, isLoading: false }));
@@ -56,6 +70,34 @@ export default function ApplicationDetailModal({
     };
     fetchDetail();
   }, [app.studentId]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const normLevel = selectedLevel === "" ? null : selectedLevel;
+      const initialNormLevel =
+        normalizeClassLevel(detail.classLevel) === "" ? null : normalizeClassLevel(detail.classLevel);
+
+      if (normLevel !== initialNormLevel) {
+        await onUpdateClassLevel(normLevel);
+      }
+
+      const initialStatus =
+        detail.isApprove === true ? "ACCEPTED" : detail.isApprove === false ? "REJECTED" : "PENDING";
+      if (selectedStatus !== initialStatus) {
+        if (selectedStatus === "ACCEPTED") {
+          await onUpdateStatus(true);
+        } else if (selectedStatus === "REJECTED") {
+          await onUpdateStatus(false);
+        }
+      }
+    } catch (e) {
+      console.error("Failed to save changes", e);
+    } finally {
+      setIsSaving(false);
+      onClose();
+    }
+  };
 
   const statusLabel =
     detail.isApprove === true ? "합격" : detail.isApprove === false ? "불합격" : "대기중";
@@ -144,66 +186,80 @@ export default function ApplicationDetailModal({
           </div>
         </div>
 
-        {/* 하단 */}
-        <div className="px-5 md:px-8 py-4 border-t border-neutral-200 shrink-0 space-y-3">
-          {/* 반 배정 */}
-          <div className="flex items-center gap-2">
-            <div className="relative flex-1">
-              <select
-                value={selectedLevel}
-                onChange={(e) => setSelectedLevel(e.target.value)}
-                className="w-full appearance-none border border-neutral-300 bg-white px-3 py-2 pr-8 text-sm font-medium outline-none focus:border-black transition-colors"
-              >
-                {CLASS_LEVELS.map((l) => (
-                  <option key={l.value} value={l.value}>
-                    {l.label}
-                  </option>
-                ))}
-              </select>
-              <ChevronDown
-                size={14}
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-neutral-400 pointer-events-none"
-              />
+        {/* 하단 컨트롤 및 저장 버튼 */}
+        <div className="px-5 md:px-8 py-5 border-t border-neutral-200 shrink-0 bg-neutral-50/50 space-y-4">
+          {/* 2열 레이아웃: 좌측 반 선택, 우측 합격/불합격/미정 선택 */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {/* 좌측: 반 선택 */}
+            <div>
+              <label className="text-[10px] font-bold tracking-[0.15em] text-neutral-400 block mb-1.5 uppercase">
+                반 배정
+              </label>
+              <div className="relative">
+                <select
+                  value={selectedLevel}
+                  onChange={(e) => setSelectedLevel(e.target.value)}
+                  className="w-full appearance-none border border-neutral-300 bg-white px-3.5 py-2 pr-8 text-xs font-bold text-neutral-900 outline-none focus:border-black transition-colors"
+                >
+                  {CLASS_LEVELS.map((l) => (
+                    <option key={l.value} value={l.value}>
+                      {l.label}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown
+                  size={14}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-neutral-400 pointer-events-none"
+                />
+              </div>
             </div>
-            <button
-              type="button"
-              onClick={() => onUpdateClassLevel(selectedLevel === "" ? null : selectedLevel)}
-              className="px-4 py-2 border border-neutral-300 text-sm font-bold hover:bg-neutral-50 transition-colors shrink-0"
-            >
-              반 저장
-            </button>
+
+            {/* 우측: 합격 여부 선택 */}
+            <div>
+              <label className="text-[10px] font-bold tracking-[0.15em] text-neutral-400 block mb-1.5 uppercase">
+                합격 여부
+              </label>
+              <div className="relative">
+                <select
+                  value={selectedStatus}
+                  onChange={(e) =>
+                    setSelectedStatus(e.target.value as "PENDING" | "ACCEPTED" | "REJECTED")
+                  }
+                  className="w-full appearance-none border border-neutral-300 bg-white px-3.5 py-2 pr-8 text-xs font-bold text-neutral-900 outline-none focus:border-black transition-colors"
+                >
+                  <option value="PENDING">미정 (대기중)</option>
+                  <option value="ACCEPTED">합격</option>
+                  <option value="REJECTED">불합격</option>
+                </select>
+                <ChevronDown
+                  size={14}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-neutral-400 pointer-events-none"
+                />
+              </div>
+            </div>
           </div>
 
-          {/* 합격/불합격 + 닫기 */}
-          <div className="flex items-center justify-between">
+          {/* 하단 버튼 */}
+          <div className="flex items-center justify-between pt-2">
             <span className="text-[10px] font-bold tracking-[0.25em] text-neutral-300">
               SOLUTIO NEST
             </span>
             <div className="flex items-center gap-2">
-              {detail.isApprove !== false && (
-                <button
-                  type="button"
-                  onClick={() => onUpdateStatus(false)}
-                  className="px-4 py-2 border border-neutral-300 text-sm font-bold text-red-600 hover:bg-red-50 hover:border-red-200 transition-colors"
-                >
-                  불합격
-                </button>
-              )}
-              {detail.isApprove !== true && (
-                <button
-                  type="button"
-                  onClick={() => onUpdateStatus(true)}
-                  className="px-4 py-2 bg-neutral-900 text-white text-sm font-bold hover:bg-neutral-800 transition-colors"
-                >
-                  합격
-                </button>
-              )}
               <button
                 type="button"
                 onClick={onClose}
-                className="px-4 py-2 border border-neutral-300 text-sm font-bold text-neutral-600 hover:bg-neutral-50 transition-colors"
+                disabled={isSaving}
+                className="px-4 py-2 border border-neutral-300 text-xs font-bold text-neutral-600 hover:bg-neutral-100 transition-colors disabled:opacity-50"
               >
                 닫기
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={isSaving}
+                className="px-5 py-2 bg-neutral-900 text-white text-xs font-bold hover:bg-neutral-800 transition-colors shadow-sm disabled:opacity-50"
+              >
+                {isSaving ? "저장 중..." : "저장"}
               </button>
             </div>
           </div>

--- a/src/features/admin/components/ApplicationFilter.tsx
+++ b/src/features/admin/components/ApplicationFilter.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 function isUnassignedClass(raw: string | null | undefined): boolean {
-  if (!raw || raw === "미정") return true;
+  if (!raw || raw === "미정" || raw === "미배정") return true;
   const upper = raw.toUpperCase();
   return !["SEED", "BRANCH", "TREE"].includes(upper);
 }
@@ -15,7 +15,7 @@ function isUnassignedClass(raw: string | null | undefined): boolean {
 const FILTERS = [
   { key: "ALL", label: "전체", eng: "ALL" },
   { key: "PENDING", label: "미처리", eng: "PENDING" },
-  { key: "ACCEPTED", label: "합격", eng: "ACCEPTED" },
+  { key: "APPROVED", label: "합격", eng: "APPROVED" },
   { key: "REJECTED", label: "불합격", eng: "REJECTED" },
   { key: "UNASSIGNED_CLASS", label: "반 미정", eng: "UNASSIGNED_CLASS" },
 ] as const;
@@ -23,9 +23,9 @@ const FILTERS = [
 export default function ApplicationFilter({ filter, setFilter, applications }: Props) {
   const getCount = (status: string) => {
     if (status === "ALL") return applications.length;
-    if (status === "PENDING") return applications.filter((a) => a.isApprove === null).length;
-    if (status === "ACCEPTED") return applications.filter((a) => a.isApprove === true).length;
-    if (status === "REJECTED") return applications.filter((a) => a.isApprove === false).length;
+    if (status === "PENDING") return applications.filter((a) => a.passStatus === "PENDING").length;
+    if (status === "APPROVED" || status === "ACCEPTED") return applications.filter((a) => a.passStatus === "APPROVED").length;
+    if (status === "REJECTED") return applications.filter((a) => a.passStatus === "REJECTED").length;
     if (status === "UNASSIGNED_CLASS") return applications.filter((a) => isUnassignedClass(a.classLevel)).length;
     return 0;
   };

--- a/src/features/admin/components/ApplicationFilter.tsx
+++ b/src/features/admin/components/ApplicationFilter.tsx
@@ -6,30 +6,38 @@ interface Props {
   applications: ApplicantResponseDto[];
 }
 
+function isUnassignedClass(raw: string | null | undefined): boolean {
+  if (!raw || raw === "미정") return true;
+  const upper = raw.toUpperCase();
+  return !["SEED", "BRANCH", "TREE"].includes(upper);
+}
+
 const FILTERS = [
   { key: "ALL", label: "전체", eng: "ALL" },
-  { key: "PENDING", label: "대기중", eng: "PENDING" },
+  { key: "PENDING", label: "미처리", eng: "PENDING" },
   { key: "ACCEPTED", label: "합격", eng: "ACCEPTED" },
   { key: "REJECTED", label: "불합격", eng: "REJECTED" },
+  { key: "UNASSIGNED_CLASS", label: "반 미정", eng: "UNASSIGNED_CLASS" },
 ] as const;
 
 export default function ApplicationFilter({ filter, setFilter, applications }: Props) {
   const getCount = (status: string) => {
     if (status === "ALL") return applications.length;
+    if (status === "PENDING") return applications.filter((a) => a.isApprove === null).length;
     if (status === "ACCEPTED") return applications.filter((a) => a.isApprove === true).length;
     if (status === "REJECTED") return applications.filter((a) => a.isApprove === false).length;
-    if (status === "PENDING") return applications.filter((a) => a.isApprove === null).length;
+    if (status === "UNASSIGNED_CLASS") return applications.filter((a) => isUnassignedClass(a.classLevel)).length;
     return 0;
   };
 
   return (
-    <div className="flex items-center gap-0 mb-6 border-b border-neutral-300">
+    <div className="flex items-center gap-0 mb-6 border-b border-neutral-300 overflow-x-auto">
       {FILTERS.map((f) => (
         <button
           key={f.key}
           type="button"
           onClick={() => setFilter(f.key)}
-          className={`px-4 py-3 text-sm font-bold border-b-2 transition-colors ${
+          className={`px-4 py-3 text-sm font-bold border-b-2 transition-colors whitespace-nowrap ${
             filter === f.key
               ? "border-black text-black"
               : "border-transparent text-neutral-400 hover:text-neutral-600"

--- a/src/features/admin/components/ApplicationFilter.tsx
+++ b/src/features/admin/components/ApplicationFilter.tsx
@@ -31,28 +31,40 @@ export default function ApplicationFilter({ filter, setFilter, applications }: P
   };
 
   return (
-    <div className="flex items-center gap-0 mb-6 border-b border-neutral-300 overflow-x-auto">
-      {FILTERS.map((f) => (
-        <button
-          key={f.key}
-          type="button"
-          onClick={() => setFilter(f.key)}
-          className={`px-4 py-3 text-sm font-bold border-b-2 transition-colors whitespace-nowrap ${
-            filter === f.key
-              ? "border-black text-black"
-              : "border-transparent text-neutral-400 hover:text-neutral-600"
-          }`}
-        >
-          {f.label}
-          <span
-            className={`ml-2 text-[10px] font-bold tracking-wider ${
-              filter === f.key ? "text-black/60" : "text-neutral-300"
-            }`}
-          >
-            {getCount(f.key)}
-          </span>
-        </button>
-      ))}
+    <div className="bg-white border border-neutral-200 px-4 mb-6 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm h-[58px]">
+      <div className="flex items-center gap-1.5 overflow-x-auto w-full sm:w-auto">
+        {FILTERS.map((f) => {
+          const isActive = filter === f.key;
+          const count = getCount(f.key);
+          return (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => setFilter(f.key)}
+              className={`px-3 py-1.5 text-xs font-bold transition-all whitespace-nowrap flex items-center gap-1.5 ${
+                isActive
+                  ? "bg-neutral-900 text-white shadow-sm"
+                  : "bg-neutral-100 text-neutral-600 hover:bg-neutral-200 hover:text-black"
+              }`}
+            >
+              <span>{f.label}</span>
+              <span
+                className={`px-1.5 py-0.5 text-[10px] font-extrabold rounded ${
+                  isActive ? "bg-white/20 text-white" : "bg-neutral-200 text-neutral-600"
+                }`}
+              >
+                {count}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-2 w-full sm:w-auto justify-end shrink-0">
+        <span className="text-xs font-bold text-neutral-500">
+          총 <span className="text-black font-extrabold">{applications.length}</span>명 신청됨
+        </span>
+      </div>
     </div>
   );
 }

--- a/src/features/admin/components/ApplicationTable.tsx
+++ b/src/features/admin/components/ApplicationTable.tsx
@@ -1,4 +1,4 @@
-import { type ApplicantResponseDto } from "@/services/types";
+import { type ApplicantResponseDto, type PassStatus } from "@/services/types";
 import { Check, X, MoreHorizontal } from "lucide-react";
 
 interface Props {
@@ -11,14 +11,14 @@ interface Props {
   onToggleStatus: (app: ApplicantResponseDto) => void;
 }
 
-function StatusBadge({ isApprove }: { isApprove: boolean | null }) {
-  if (isApprove === true)
+function StatusBadge({ passStatus }: { passStatus: PassStatus }) {
+  if (passStatus === "APPROVED")
     return (
       <span className="px-2.5 py-0.5 text-[10px] font-bold tracking-widest border border-green-400 text-green-700 bg-green-50">
         합격
       </span>
     );
-  if (isApprove === false)
+  if (passStatus === "REJECTED")
     return (
       <span className="px-2.5 py-0.5 text-[10px] font-bold tracking-widest border border-red-300 text-red-600 bg-red-50">
         불합격
@@ -75,8 +75,7 @@ export default function ApplicationTable({
           </thead>
           <tbody className="divide-y divide-neutral-100">
             {applications.map((app) => {
-              const status =
-                app.isApprove === true ? "ACCEPTED" : app.isApprove === false ? "REJECTED" : "PENDING";
+              const status = app.passStatus;
               return (
                 <tr
                   key={app.studentId}
@@ -101,18 +100,18 @@ export default function ApplicationTable({
                     <span className="text-neutral-400 text-xs">
                       {new Date(app.createdAt).toLocaleDateString()}
                     </span>
-                    {app.classLevel && app.classLevel !== "미정" ? (
+                    {app.classLevel && app.classLevel !== "미정" && app.classLevel !== "미배정" ? (
                       <span className="block mt-1 text-[10px] font-bold tracking-widest text-neutral-900 bg-neutral-100 px-2 py-0.5 w-fit">
                         {app.classLevel}
                       </span>
                     ) : (
                       <span className="block mt-1 text-[10px] font-bold tracking-widest text-neutral-400 bg-neutral-100 border border-neutral-200 px-2 py-0.5 w-fit">
-                        미정
+                        미배정
                       </span>
                     )}
                   </td>
                   <td className="px-5 py-4">
-                    <StatusBadge isApprove={app.isApprove} />
+                    <StatusBadge passStatus={app.passStatus} />
                   </td>
                   <td className="px-5 py-4 text-right" onClick={(e) => e.stopPropagation()}>
                     <div className="flex items-center justify-end gap-1">
@@ -128,13 +127,13 @@ export default function ApplicationTable({
                         type="button"
                         onClick={() => onToggleStatus(app)}
                         className={`p-2 transition-colors ${
-                          status === "ACCEPTED"
+                          status === "APPROVED"
                             ? "text-green-600 hover:bg-red-50 hover:text-red-600"
                             : "text-neutral-300 hover:bg-green-50 hover:text-green-600"
                         }`}
-                        title={status === "ACCEPTED" ? "불합격 처리" : "합격 처리"}
+                        title={status === "APPROVED" ? "불합격 처리" : "합격 처리"}
                       >
-                        {status === "ACCEPTED" ? <X size={16} /> : <Check size={16} />}
+                        {status === "APPROVED" ? <X size={16} /> : <Check size={16} />}
                       </button>
                     </div>
                   </td>

--- a/src/features/admin/components/ApplicationTable.tsx
+++ b/src/features/admin/components/ApplicationTable.tsx
@@ -78,8 +78,12 @@ export default function ApplicationTable({
               const status =
                 app.isApprove === true ? "ACCEPTED" : app.isApprove === false ? "REJECTED" : "PENDING";
               return (
-                <tr key={app.studentId} className="hover:bg-neutral-50 transition-colors">
-                  <td className="px-5 py-4">
+                <tr
+                  key={app.studentId}
+                  className="hover:bg-neutral-50 transition-colors group cursor-pointer"
+                  onClick={() => onSelectApp(app)}
+                >
+                  <td className="px-5 py-4" onClick={(e) => e.stopPropagation()}>
                     <input
                       type="checkbox"
                       checked={selectedIds.has(app.studentId)}
@@ -88,7 +92,7 @@ export default function ApplicationTable({
                     />
                   </td>
                   <td className="px-5 py-4">
-                    <span className="font-bold text-neutral-900">{app.name}</span>
+                    <span className="font-bold text-neutral-900 group-hover:text-black">{app.name}</span>
                     <span className="block text-xs text-neutral-400 mt-0.5">{app.department}</span>
                   </td>
                   <td className="px-5 py-4 text-neutral-600 font-mono text-xs">{app.studentId}</td>
@@ -97,16 +101,20 @@ export default function ApplicationTable({
                     <span className="text-neutral-400 text-xs">
                       {new Date(app.createdAt).toLocaleDateString()}
                     </span>
-                    {app.classLevel && app.classLevel !== "미정" && (
+                    {app.classLevel && app.classLevel !== "미정" ? (
                       <span className="block mt-1 text-[10px] font-bold tracking-widest text-neutral-900 bg-neutral-100 px-2 py-0.5 w-fit">
                         {app.classLevel}
+                      </span>
+                    ) : (
+                      <span className="block mt-1 text-[10px] font-bold tracking-widest text-neutral-400 bg-neutral-100 border border-neutral-200 px-2 py-0.5 w-fit">
+                        미정
                       </span>
                     )}
                   </td>
                   <td className="px-5 py-4">
                     <StatusBadge isApprove={app.isApprove} />
                   </td>
-                  <td className="px-5 py-4 text-right">
+                  <td className="px-5 py-4 text-right" onClick={(e) => e.stopPropagation()}>
                     <div className="flex items-center justify-end gap-1">
                       <button
                         type="button"

--- a/src/features/admin/components/BlacklistAddModal.tsx
+++ b/src/features/admin/components/BlacklistAddModal.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { X, ShieldAlert, Loader2 } from "lucide-react";
+import { blacklistService } from "@/services/api";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function BlacklistAddModal({ isOpen, onClose, onSuccess }: Props) {
+  const [studentId, setStudentId] = useState("");
+  const [reason, setReason] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!studentId.trim()) {
+      setErrorMessage("학번을 입력해주세요.");
+      return;
+    }
+    if (!reason.trim()) {
+      setErrorMessage("블랙리스트 등록 사유를 입력해주세요.");
+      return;
+    }
+
+    setLoading(true);
+    setErrorMessage(null);
+
+    try {
+      await blacklistService.add({
+        studentId: studentId.trim(),
+        reason: reason.trim(),
+      });
+      alert("블랙리스트 대상자가 성공적으로 등록되었습니다.");
+      setStudentId("");
+      setReason("");
+      onSuccess();
+      onClose();
+    } catch (e: unknown) {
+      console.error(e);
+      let msg = "등록 중 오류가 발생했습니다.";
+      if (e && typeof e === "object" && "response" in e) {
+        const res = (e as { response?: { data?: { message?: string } } }).response;
+        if (res?.data?.message) {
+          msg = res.data.message;
+        }
+      }
+      setErrorMessage(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* 배경 오버레이 */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        onClick={onClose}
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+      />
+
+      {/* 모달 컨텐츠 */}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 10 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+        className="relative bg-white w-full max-w-lg shadow-2xl border border-neutral-200 overflow-hidden z-10"
+      >
+        {/* 헤더 */}
+        <div className="px-6 py-5 border-b border-neutral-200 flex items-center justify-between bg-neutral-900 text-white">
+          <div className="flex items-center gap-2.5">
+            <ShieldAlert size={20} className="text-red-400" />
+            <h2 className="text-lg font-black tracking-tight">블랙리스트 등록</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 hover:bg-neutral-800 text-neutral-400 hover:text-white transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* 폼 */}
+        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+          {errorMessage && (
+            <div className="p-3 bg-red-50 border border-red-200 text-red-700 text-xs font-semibold rounded">
+              {errorMessage}
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="studentId" className="block text-xs font-extrabold text-neutral-700 uppercase tracking-wider mb-2">
+              학번 <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="studentId"
+              type="text"
+              placeholder="예: 202412345"
+              value={studentId}
+              onChange={(e) => setStudentId(e.target.value)}
+              className="w-full px-4 py-2.5 bg-neutral-50 border border-neutral-300 text-sm font-mono text-neutral-900 focus:outline-none focus:border-black focus:bg-white transition-colors"
+            />
+            <p className="text-[11px] text-neutral-400 mt-1">
+              제재 처리할 대상자의 학번을 정확하게 입력하세요.
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor="reason" className="block text-xs font-extrabold text-neutral-700 uppercase tracking-wider mb-2">
+              등록 사유 <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              id="reason"
+              rows={4}
+              placeholder="블랙리스트 등록 사유를 입력하세요 (예: 동아리 규정 위반, 무단 노쇼 등)"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="w-full px-4 py-2.5 bg-neutral-50 border border-neutral-300 text-sm text-neutral-900 focus:outline-none focus:border-black focus:bg-white transition-colors resize-none"
+            />
+          </div>
+
+          <div className="pt-3 flex items-center justify-end gap-2 border-t border-neutral-100">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2.5 text-xs font-bold text-neutral-600 hover:bg-neutral-100 transition-colors"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="px-5 py-2.5 bg-red-600 hover:bg-red-700 text-white font-bold text-xs tracking-wider transition-colors disabled:opacity-50 flex items-center gap-2"
+            >
+              {loading && <Loader2 size={14} className="animate-spin" />}
+              블랙리스트 추가
+            </button>
+          </div>
+        </form>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/features/admin/components/BlacklistDetailModal.tsx
+++ b/src/features/admin/components/BlacklistDetailModal.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState, useCallback } from "react";
+import { motion } from "framer-motion";
+import { X, ShieldAlert, Edit2, Trash2, Mail, Phone, Calendar, BookOpen, type LucideIcon } from "lucide-react";
+import { blacklistService } from "@/services/api";
+import type { BlacklistDetailResponseDto } from "@/services/types";
+
+interface Props {
+  blacklistId: number;
+  onClose: () => void;
+  onEditReason: (detail: BlacklistDetailResponseDto) => void;
+  onDelete: (id: number) => void;
+}
+
+export default function BlacklistDetailModal({
+  blacklistId,
+  onClose,
+  onEditReason,
+  onDelete,
+}: Props) {
+  const [detail, setDetail] = useState<BlacklistDetailResponseDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadDetail = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await blacklistService.getDetail(blacklistId);
+      setDetail(data);
+    } catch (e: unknown) {
+      console.error(e);
+      setError("상세 정보를 불러올 수 없습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, [blacklistId]);
+
+  useEffect(() => {
+    loadDetail();
+  }, [loadDetail]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* 오버레이 */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        onClick={onClose}
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+      />
+
+      {/* 모달 박스 */}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 10 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+        className="relative bg-white w-full max-w-xl shadow-2xl border border-neutral-200 overflow-hidden z-10"
+      >
+        {/* 헤더 */}
+        <div className="px-6 py-5 border-b border-neutral-200 flex items-center justify-between bg-neutral-900 text-white">
+          <div className="flex items-center gap-2.5">
+            <ShieldAlert size={20} className="text-red-400" />
+            <h2 className="text-lg font-black tracking-tight">블랙리스트 상세 정보</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 hover:bg-neutral-800 text-neutral-400 hover:text-white transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* 바디 */}
+        <div className="p-6">
+          {loading ? (
+            <div className="py-12 flex flex-col items-center justify-center gap-3">
+              <div className="w-6 h-6 border-2 border-neutral-200 border-t-red-500 rounded-full animate-spin" />
+              <span className="text-xs text-neutral-400 font-semibold">불러오는 중...</span>
+            </div>
+          ) : error ? (
+            <div className="py-12 text-center text-red-500 font-semibold text-sm">
+              {error}
+            </div>
+          ) : detail ? (
+            <div className="space-y-6">
+              {/* 기본 프로필 카드 */}
+              <div className="p-4 bg-red-50/50 border border-red-100 flex items-center justify-between">
+                <div>
+                  <span className="text-xs font-mono font-bold text-red-600 bg-red-100 px-2 py-0.5 rounded">
+                    학번 {detail.studentId}
+                  </span>
+                  <h3 className="text-xl font-black text-neutral-900 mt-1">
+                    {detail.name || "미등록/알 수 없음"}
+                  </h3>
+                </div>
+                <div className="text-right">
+                  <span className="text-[10px] font-extrabold tracking-widest text-red-600 bg-red-100 px-2.5 py-1 uppercase rounded-full">
+                    차단 대상자
+                  </span>
+                </div>
+              </div>
+
+              {/* 상세 인포 그리드 */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <InfoItem icon={BookOpen} label="학과" value={detail.department || "-"} />
+                <InfoItem icon={Mail} label="이메일" value={detail.email || "-"} />
+                <InfoItem icon={Phone} label="전화번호" value={detail.phoneNumber || "-"} />
+                <InfoItem
+                  icon={Calendar}
+                  label="등록일시"
+                  value={
+                    detail.createdAt
+                      ? new Date(detail.createdAt).toLocaleString("ko-KR")
+                      : "-"
+                  }
+                />
+              </div>
+
+              {/* 차단 사유 */}
+              <div>
+                <label className="block text-xs font-extrabold text-neutral-500 uppercase tracking-wider mb-2">
+                  블랙리스트 등록 사유
+                </label>
+                <div className="p-4 bg-neutral-50 border border-neutral-200 text-neutral-800 text-sm whitespace-pre-wrap leading-relaxed font-medium">
+                  {detail.reason || "등록된 사유가 없습니다."}
+                </div>
+              </div>
+
+              {/* 버튼 그룹 */}
+              <div className="pt-4 flex items-center justify-between border-t border-neutral-100">
+                <button
+                  type="button"
+                  onClick={() => onDelete(detail.id)}
+                  className="px-4 py-2.5 bg-red-50 hover:bg-red-100 text-red-600 font-bold text-xs flex items-center gap-1.5 transition-colors border border-red-200"
+                >
+                  <Trash2 size={14} />
+                  블랙리스트 해제
+                </button>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onEditReason(detail)}
+                    className="px-4 py-2.5 bg-neutral-900 hover:bg-black text-white font-bold text-xs flex items-center gap-1.5 transition-colors"
+                  >
+                    <Edit2 size={14} />
+                    사유 수정
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+function InfoItem({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 p-3 bg-neutral-50/70 border border-neutral-200/60">
+      <Icon size={16} className="text-neutral-400 mt-0.5 shrink-0" />
+      <div className="min-w-0">
+        <span className="text-[10px] font-extrabold text-neutral-400 uppercase tracking-wider block">
+          {label}
+        </span>
+        <span className="text-xs font-bold text-neutral-800 truncate block mt-0.5">
+          {value}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/components/BlacklistEditModal.tsx
+++ b/src/features/admin/components/BlacklistEditModal.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect } from "react";
+import { motion } from "framer-motion";
+import { X, Edit2, Loader2 } from "lucide-react";
+import { blacklistService } from "@/services/api";
+
+interface Props {
+  isOpen: boolean;
+  blacklistId: number;
+  currentReason: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function BlacklistEditModal({
+  isOpen,
+  blacklistId,
+  currentReason,
+  onClose,
+  onSuccess,
+}: Props) {
+  const [reason, setReason] = useState(currentReason);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setReason(currentReason);
+  }, [currentReason]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!reason.trim()) {
+      setError("블랙리스트 사유를 입력하세요.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await blacklistService.updateReason(blacklistId, {
+        reason: reason.trim(),
+      });
+      alert("사유가 변경되었습니다.");
+      onSuccess();
+      onClose();
+    } catch (e: unknown) {
+      console.error(e);
+      setError("사유 수정 중 오류가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* 오버레이 */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        onClick={onClose}
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+      />
+
+      {/* 모달 */}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 10 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+        className="relative bg-white w-full max-w-lg shadow-2xl border border-neutral-200 overflow-hidden z-10"
+      >
+        <div className="px-6 py-5 border-b border-neutral-200 flex items-center justify-between bg-neutral-900 text-white">
+          <div className="flex items-center gap-2">
+            <Edit2 size={18} className="text-amber-400" />
+            <h2 className="text-lg font-black tracking-tight">블랙리스트 사유 수정</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 hover:bg-neutral-800 text-neutral-400 hover:text-white transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          {error && (
+            <div className="p-3 bg-red-50 border border-red-200 text-red-700 text-xs font-semibold rounded">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="editReason" className="block text-xs font-extrabold text-neutral-700 uppercase tracking-wider mb-2">
+              수정할 사유 <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              id="editReason"
+              rows={4}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="w-full px-4 py-2.5 bg-neutral-50 border border-neutral-300 text-sm text-neutral-900 focus:outline-none focus:border-black focus:bg-white transition-colors resize-none"
+            />
+          </div>
+
+          <div className="pt-3 flex items-center justify-end gap-2 border-t border-neutral-100">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2.5 text-xs font-bold text-neutral-600 hover:bg-neutral-100 transition-colors"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="px-5 py-2.5 bg-black hover:bg-neutral-800 text-white font-bold text-xs tracking-wider transition-colors disabled:opacity-50 flex items-center gap-2"
+            >
+              {loading && <Loader2 size={14} className="animate-spin" />}
+              저장
+            </button>
+          </div>
+        </form>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/features/admin/components/BlacklistTable.tsx
+++ b/src/features/admin/components/BlacklistTable.tsx
@@ -1,0 +1,134 @@
+import type { BlacklistResponseDto } from "@/services/types";
+import { Edit2, Trash2, ShieldAlert } from "lucide-react";
+
+interface Props {
+  blacklists: BlacklistResponseDto[];
+  loading: boolean;
+  onViewDetail: (item: BlacklistResponseDto) => void;
+  onEditReason: (item: BlacklistResponseDto) => void;
+  onDelete: (item: BlacklistResponseDto) => void;
+}
+
+export default function BlacklistTable({
+  blacklists,
+  loading,
+  onViewDetail,
+  onEditReason,
+  onDelete,
+}: Props) {
+  if (loading) {
+    return (
+      <div className="bg-white border border-neutral-200 overflow-hidden shadow-sm">
+        <div className="flex flex-col items-center justify-center py-16 gap-3">
+          <div className="w-6 h-6 border-2 border-neutral-200 border-t-red-500 rounded-full animate-spin" />
+          <span className="text-sm font-semibold text-neutral-400">
+            블랙리스트 목록을 불러오는 중...
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white border border-neutral-200 overflow-hidden shadow-sm">
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="border-b border-neutral-200 bg-neutral-50/50">
+            <tr>
+              <Th>이름 / 학과</Th>
+              <Th>학번</Th>
+              <Th>등록 일시</Th>
+              <Th align="right">관리</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-100">
+            {blacklists.map((item) => (
+              <tr
+                key={item.id}
+                className="hover:bg-neutral-50/80 transition-colors group cursor-pointer"
+                onClick={() => onViewDetail(item)}
+              >
+                <td className="px-5 py-4">
+                  <div className="flex items-center gap-3">
+                    <div className="w-9 h-9 rounded-full bg-red-50 text-red-600 flex items-center justify-center font-bold text-sm shrink-0 border border-red-100">
+                      {item.name ? item.name.charAt(0) : "차"}
+                    </div>
+                    <div>
+                      <span className="font-bold text-neutral-900 group-hover:text-black">
+                        {item.name || "미등록/탈퇴 사용자"}
+                      </span>
+                      <span className="block text-xs text-neutral-400 mt-0.5">
+                        {item.department || "학과 정보 없음"}
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-5 py-4">
+                  <span className="font-mono text-xs font-semibold text-neutral-700 bg-neutral-100 border border-neutral-200 px-2.5 py-1 rounded inline-block">
+                    {item.studentId}
+                  </span>
+                </td>
+                <td className="px-5 py-4 text-xs text-neutral-500 font-medium">
+                  {item.createdAt ? new Date(item.createdAt).toLocaleString("ko-KR", {
+                    year: "numeric",
+                    month: "2-digit",
+                    day: "2-digit",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  }) : "-"}
+                </td>
+                <td className="px-5 py-4 text-right" onClick={(e) => e.stopPropagation()}>
+                  <div className="flex items-center justify-end gap-1">
+                    <button
+                      type="button"
+                      onClick={() => onEditReason(item)}
+                      className="p-2 hover:bg-neutral-100 text-neutral-500 hover:text-amber-600 transition-colors rounded"
+                      title="사유 수정"
+                    >
+                      <Edit2 size={16} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(item)}
+                      className="p-2 hover:bg-red-50 text-neutral-400 hover:text-red-600 transition-colors rounded"
+                      title="블랙리스트 해제"
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {blacklists.length === 0 && (
+              <tr>
+                <td colSpan={4} className="px-5 py-16 text-center">
+                  <div className="flex flex-col items-center justify-center gap-2">
+                    <ShieldAlert size={36} className="text-neutral-300 stroke-[1.5]" />
+                    <p className="text-neutral-500 font-semibold text-sm">
+                      등록된 블랙리스트 대상자가 없습니다.
+                    </p>
+                    <p className="text-xs text-neutral-400">
+                      새로운 차단 대상자가 있는 경우 우측 상단의 등록 버튼을 이용해주세요.
+                    </p>
+                  </div>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function Th({ children, align }: { children: React.ReactNode; align?: "right" }) {
+  return (
+    <th
+      className={`px-5 py-3.5 text-[11px] font-extrabold tracking-[0.15em] text-neutral-400 uppercase ${
+        align === "right" ? "text-right" : ""
+      }`}
+    >
+      {children}
+    </th>
+  );
+}

--- a/src/features/admin/pages/ApplicationListPage.tsx
+++ b/src/features/admin/pages/ApplicationListPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
 
 import { applicantService, recruitmentService } from "@/services/api";
-import type { ApplicantResponseDto } from "@/services/types";
+import type { ApplicantResponseDto, PassStatus } from "@/services/types";
 import { AnimatePresence } from "framer-motion";
 import { Loader2, Users } from "lucide-react";
 import AdminSubNav from "../components/AdminSubNav";
@@ -65,25 +65,25 @@ export default function ApplicationListPage() {
     }
   };
 
-  const toggleStatus = async (app: ApplicantResponseDto, explicitStatus?: boolean) => {
-    let targetStatus: boolean;
+  const toggleStatus = async (app: ApplicantResponseDto, explicitStatus?: PassStatus) => {
+    let targetStatus: PassStatus;
     if (explicitStatus !== undefined) {
       targetStatus = explicitStatus;
     } else {
-      if (app.isApprove === null) targetStatus = true;
-      else if (app.isApprove === true) targetStatus = false;
-      else targetStatus = true;
+      if (app.passStatus === "PENDING") targetStatus = "APPROVED";
+      else if (app.passStatus === "APPROVED") targetStatus = "REJECTED";
+      else targetStatus = "APPROVED";
     }
     try {
       setApplications((prev) =>
-        prev.map((a) => (a.studentId === app.studentId ? { ...a, isApprove: targetStatus } : a))
+        prev.map((a) => (a.studentId === app.studentId ? { ...a, passStatus: targetStatus } : a))
       );
       if (selectedApp && selectedApp.studentId === app.studentId) {
-        setSelectedApp({ ...selectedApp, isApprove: targetStatus });
+        setSelectedApp({ ...selectedApp, passStatus: targetStatus });
       }
-      if (targetStatus) {
+      if (targetStatus === "APPROVED") {
         await applicantService.approve(app.studentId);
-      } else {
+      } else if (targetStatus === "REJECTED") {
         await applicantService.reject(app.studentId);
       }
     } catch (e) {
@@ -121,9 +121,13 @@ export default function ApplicationListPage() {
       console.error(e);
       let errorMessage = "처리 중 오류가 발생했습니다.";
       if (e.response) {
-        errorMessage += `\n상태 코드: ${e.response.status}`;
-        if (e.response.data?.message) errorMessage += `\n메시지: ${e.response.data.message}`;
-        else if (e.response.data?.detail) errorMessage += `\n상세: ${e.response.data.detail}`;
+        if (e.response.status === 409) {
+          errorMessage = "승인 실패 (409 CONFLICT): '합격(APPROVED)' 상태인 지원자만 계정 생성 승인이 가능합니다.";
+        } else {
+          errorMessage += `\n상태 코드: ${e.response.status}`;
+          if (e.response.data?.message) errorMessage += `\n메시지: ${e.response.data.message}`;
+          else if (e.response.data?.detail) errorMessage += `\n상세: ${e.response.data.detail}`;
+        }
       }
       alert(errorMessage);
     } finally {
@@ -140,11 +144,11 @@ export default function ApplicationListPage() {
 
   const filteredApps = applications.filter((app) => {
     if (filter === "ALL") return true;
-    if (filter === "PENDING") return app.isApprove === null;
-    if (filter === "ACCEPTED") return app.isApprove === true;
-    if (filter === "REJECTED") return app.isApprove === false;
+    if (filter === "PENDING") return app.passStatus === "PENDING";
+    if (filter === "APPROVED" || filter === "ACCEPTED") return app.passStatus === "APPROVED";
+    if (filter === "REJECTED") return app.passStatus === "REJECTED";
     if (filter === "UNASSIGNED_CLASS") {
-      if (!app.classLevel || app.classLevel === "미정") return true;
+      if (!app.classLevel || app.classLevel === "미정" || app.classLevel === "미배정") return true;
       const upper = app.classLevel.toUpperCase();
       return !["SEED", "BRANCH", "TREE"].includes(upper);
     }

--- a/src/features/admin/pages/ApplicationListPage.tsx
+++ b/src/features/admin/pages/ApplicationListPage.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "@/context/AuthContext";
 import { applicantService, recruitmentService } from "@/services/api";
 import type { ApplicantResponseDto } from "@/services/types";
 import { AnimatePresence } from "framer-motion";
-import { Loader2 } from "lucide-react";
+import { Loader2, Users } from "lucide-react";
 import AdminSubNav from "../components/AdminSubNav";
 import ApplicationDetailModal from "../components/ApplicationDetailModal";
 import ApplicationFilter from "../components/ApplicationFilter";
@@ -163,12 +163,13 @@ export default function ApplicationListPage() {
     <div className="min-h-screen bg-neutral-100 text-black">
       <div className="max-w-screen-xl mx-auto px-5 md:px-10 py-8 md:py-12">
         {/* 헤더 */}
-        <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 mb-10">
+        <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 mb-8">
           <div>
             <span className="text-[10px] font-bold tracking-[0.3em] text-neutral-400 block mb-2">
               ADMIN
             </span>
-            <h1 className="text-3xl md:text-4xl font-black tracking-tighter leading-tight">
+            <h1 className="text-3xl md:text-4xl font-black tracking-tighter leading-tight flex items-center gap-3">
+              <Users className="text-neutral-900" size={36} />
               신청 관리
             </h1>
             <p className="text-sm font-medium text-neutral-500 mt-2">

--- a/src/features/admin/pages/ApplicationListPage.tsx
+++ b/src/features/admin/pages/ApplicationListPage.tsx
@@ -6,6 +6,7 @@ import { applicantService, recruitmentService } from "@/services/api";
 import type { ApplicantResponseDto } from "@/services/types";
 import { AnimatePresence } from "framer-motion";
 import { Loader2 } from "lucide-react";
+import AdminSubNav from "../components/AdminSubNav";
 import ApplicationDetailModal from "../components/ApplicationDetailModal";
 import ApplicationFilter from "../components/ApplicationFilter";
 import ApplicationTable from "../components/ApplicationTable";
@@ -139,9 +140,14 @@ export default function ApplicationListPage() {
 
   const filteredApps = applications.filter((app) => {
     if (filter === "ALL") return true;
+    if (filter === "PENDING") return app.isApprove === null;
     if (filter === "ACCEPTED") return app.isApprove === true;
     if (filter === "REJECTED") return app.isApprove === false;
-    if (filter === "PENDING") return app.isApprove === null;
+    if (filter === "UNASSIGNED_CLASS") {
+      if (!app.classLevel || app.classLevel === "미정") return true;
+      const upper = app.classLevel.toUpperCase();
+      return !["SEED", "BRANCH", "TREE"].includes(upper);
+    }
     return true;
   });
 
@@ -179,6 +185,8 @@ export default function ApplicationListPage() {
             {selectedIds.size}명 일괄 합격
           </button>
         </div>
+
+        <AdminSubNav />
 
         <ApplicationFilter filter={filter} setFilter={setFilter} applications={applications} />
 

--- a/src/features/admin/pages/BlacklistPage.tsx
+++ b/src/features/admin/pages/BlacklistPage.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "@/context/AuthContext";
 import { blacklistService } from "@/services/api";
 import type { BlacklistResponseDto, BlacklistDetailResponseDto } from "@/services/types";
 import { AnimatePresence } from "framer-motion";
-import { Plus, Search, ShieldAlert, ChevronLeft, ChevronRight } from "lucide-react";
+import { Plus, ShieldAlert, ChevronLeft, ChevronRight } from "lucide-react";
 import AdminSubNav from "../components/AdminSubNav";
 import BlacklistTable from "../components/BlacklistTable";
 import BlacklistAddModal from "../components/BlacklistAddModal";
@@ -17,7 +17,6 @@ export default function BlacklistPage() {
 
   const [blacklists, setBlacklists] = useState<BlacklistResponseDto[]>([]);
   const [loading, setLoading] = useState(true);
-  const [searchQuery, setSearchQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(1);
   const [totalElements, setTotalElements] = useState(0);
@@ -80,16 +79,6 @@ export default function BlacklistPage() {
     }
   };
 
-  const filteredBlacklists = blacklists.filter((item) => {
-    if (!searchQuery.trim()) return true;
-    const query = searchQuery.toLowerCase();
-    return (
-      item.studentId?.toLowerCase().includes(query) ||
-      item.name?.toLowerCase().includes(query) ||
-      item.department?.toLowerCase().includes(query)
-    );
-  });
-
   return (
     <div className="min-h-screen bg-neutral-100 text-black">
       <div className="max-w-screen-xl mx-auto px-5 md:px-10 py-8 md:py-12">
@@ -120,29 +109,16 @@ export default function BlacklistPage() {
         {/* 탭 네비게이션 */}
         <AdminSubNav />
 
-        {/* 필터 및 검색 바 */}
-        <div className="bg-white border border-neutral-200 p-4 mb-6 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm">
-          <div className="relative w-full sm:w-80">
-            <Search size={16} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-neutral-400" />
-            <input
-              type="text"
-              placeholder="학번, 이름, 학과로 검색..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-neutral-50 border border-neutral-200 text-xs font-semibold focus:outline-none focus:border-black focus:bg-white transition-colors"
-            />
-          </div>
-
-          <div className="flex items-center gap-2 w-full sm:w-auto justify-end">
-            <span className="text-xs font-bold text-neutral-500">
-              총 <span className="text-red-600 font-extrabold">{totalElements}</span>명 등록됨
-            </span>
-          </div>
+        {/* 정보 바 */}
+        <div className="bg-white border border-neutral-200 px-4 mb-6 flex items-center justify-between shadow-sm h-[58px]">
+          <span className="text-xs font-bold text-neutral-500">
+            총 <span className="text-red-600 font-extrabold">{totalElements}</span>명 등록됨
+          </span>
         </div>
 
         {/* 리스트 테이블 */}
         <BlacklistTable
-          blacklists={filteredBlacklists}
+          blacklists={blacklists}
           loading={loading}
           onViewDetail={(item) => setSelectedDetailId(item.id)}
           onEditReason={(item) =>

--- a/src/features/admin/pages/BlacklistPage.tsx
+++ b/src/features/admin/pages/BlacklistPage.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/context/AuthContext";
+import { blacklistService } from "@/services/api";
+import type { BlacklistResponseDto, BlacklistDetailResponseDto } from "@/services/types";
+import { AnimatePresence } from "framer-motion";
+import { Plus, Search, ShieldAlert, ChevronLeft, ChevronRight } from "lucide-react";
+import AdminSubNav from "../components/AdminSubNav";
+import BlacklistTable from "../components/BlacklistTable";
+import BlacklistAddModal from "../components/BlacklistAddModal";
+import BlacklistDetailModal from "../components/BlacklistDetailModal";
+import BlacklistEditModal from "../components/BlacklistEditModal";
+
+export default function BlacklistPage() {
+  const { user, isLoading: isAuthLoading } = useAuth();
+  const navigate = useNavigate();
+
+  const [blacklists, setBlacklists] = useState<BlacklistResponseDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalElements, setTotalElements] = useState(0);
+  const pageSize = 10;
+
+  // Modal States
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [selectedDetailId, setSelectedDetailId] = useState<number | null>(null);
+  const [editingTarget, setEditingTarget] = useState<{ id: number; reason: string } | null>(null);
+
+  const loadBlacklists = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await blacklistService.getList(currentPage, pageSize);
+      setBlacklists(data?.content || []);
+      setTotalPages(data?.totalPages || 1);
+      setTotalElements(data?.totalElements || (data?.content ? data.content.length : 0));
+    } catch (e) {
+      console.error("Failed to load blacklists:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, [currentPage]);
+
+  useEffect(() => {
+    if (!isAuthLoading) {
+      if (!user) {
+        navigate("/", { replace: true });
+        return;
+      }
+      if (user.role === "USER" || user.role === "GUEST") {
+        alert("접근 권한이 없습니다.");
+        navigate("/", { replace: true });
+        return;
+      }
+    }
+  }, [user, isAuthLoading, navigate]);
+
+  useEffect(() => {
+    if (user && !isAuthLoading && user.role !== "USER" && user.role !== "GUEST") {
+      loadBlacklists();
+    }
+  }, [user, isAuthLoading, loadBlacklists]);
+
+  const handleDelete = async (item: BlacklistResponseDto | { id: number; studentId?: string }) => {
+    const studentInfo = item.studentId ? ` 학번: ${item.studentId}` : "";
+    if (!confirm(`정말로 해당 대상자${studentInfo}를 블랙리스트에서 해제하시겠습니까?`)) {
+      return;
+    }
+    try {
+      await blacklistService.delete(item.id);
+      alert("블랙리스트에서 해제되었습니다.");
+      if (selectedDetailId === item.id) {
+        setSelectedDetailId(null);
+      }
+      loadBlacklists();
+    } catch (e) {
+      console.error("Failed to delete blacklist:", e);
+      alert("해제 처리 중 오류가 발생했습니다.");
+    }
+  };
+
+  const filteredBlacklists = blacklists.filter((item) => {
+    if (!searchQuery.trim()) return true;
+    const query = searchQuery.toLowerCase();
+    return (
+      item.studentId?.toLowerCase().includes(query) ||
+      item.name?.toLowerCase().includes(query) ||
+      item.department?.toLowerCase().includes(query)
+    );
+  });
+
+  return (
+    <div className="min-h-screen bg-neutral-100 text-black">
+      <div className="max-w-screen-xl mx-auto px-5 md:px-10 py-8 md:py-12">
+        {/* 헤더 */}
+        <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 mb-8">
+          <div>
+            <span className="text-[10px] font-bold tracking-[0.3em] text-neutral-400 block mb-2">
+              ADMIN
+            </span>
+            <h1 className="text-3xl md:text-4xl font-black tracking-tighter leading-tight flex items-center gap-3">
+              <ShieldAlert className="text-red-600" size={36} />
+              블랙리스트 관리
+            </h1>
+            <p className="text-sm font-medium text-neutral-500 mt-2">
+              제재 처리되거나 차단된 사용자(학번)를 등록하고 사유를 관리합니다.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsAddModalOpen(true)}
+            className="px-5 py-2.5 bg-red-600 hover:bg-red-700 text-white font-bold text-sm shadow-md transition-all flex items-center gap-2 shrink-0 hover:scale-[1.02] active:scale-[0.98]"
+          >
+            <Plus size={18} />
+            블랙리스트 추가
+          </button>
+        </div>
+
+        {/* 탭 네비게이션 */}
+        <AdminSubNav />
+
+        {/* 필터 및 검색 바 */}
+        <div className="bg-white border border-neutral-200 p-4 mb-6 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm">
+          <div className="relative w-full sm:w-80">
+            <Search size={16} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-neutral-400" />
+            <input
+              type="text"
+              placeholder="학번, 이름, 학과로 검색..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full pl-10 pr-4 py-2 bg-neutral-50 border border-neutral-200 text-xs font-semibold focus:outline-none focus:border-black focus:bg-white transition-colors"
+            />
+          </div>
+
+          <div className="flex items-center gap-2 w-full sm:w-auto justify-end">
+            <span className="text-xs font-bold text-neutral-500">
+              총 <span className="text-red-600 font-extrabold">{totalElements}</span>명 등록됨
+            </span>
+          </div>
+        </div>
+
+        {/* 리스트 테이블 */}
+        <BlacklistTable
+          blacklists={filteredBlacklists}
+          loading={loading}
+          onViewDetail={(item) => setSelectedDetailId(item.id)}
+          onEditReason={(item) =>
+            setEditingTarget({ id: item.id, reason: "" })
+          }
+          onDelete={handleDelete}
+        />
+
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2 mt-6">
+            <button
+              type="button"
+              disabled={currentPage === 0}
+              onClick={() => setCurrentPage((prev) => Math.max(0, prev - 1))}
+              className="p-2 bg-white border border-neutral-200 text-neutral-600 hover:bg-neutral-50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              <ChevronLeft size={16} />
+            </button>
+            <span className="text-xs font-bold text-neutral-600 px-3">
+              {currentPage + 1} / {totalPages}
+            </span>
+            <button
+              type="button"
+              disabled={currentPage >= totalPages - 1}
+              onClick={() => setCurrentPage((prev) => Math.min(totalPages - 1, prev + 1))}
+              className="p-2 bg-white border border-neutral-200 text-neutral-600 hover:bg-neutral-50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              <ChevronRight size={16} />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* 모달 연동 */}
+      <AnimatePresence>
+        {isAddModalOpen && (
+          <BlacklistAddModal
+            isOpen={isAddModalOpen}
+            onClose={() => setIsAddModalOpen(false)}
+            onSuccess={loadBlacklists}
+          />
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {selectedDetailId !== null && (
+          <BlacklistDetailModal
+            blacklistId={selectedDetailId}
+            onClose={() => setSelectedDetailId(null)}
+            onEditReason={(detail: BlacklistDetailResponseDto) => {
+              setSelectedDetailId(null);
+              setEditingTarget({ id: detail.id, reason: detail.reason || "" });
+            }}
+            onDelete={(id: number) => {
+              handleDelete({ id });
+            }}
+          />
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {editingTarget !== null && (
+          <BlacklistEditModal
+            isOpen={editingTarget !== null}
+            blacklistId={editingTarget.id}
+            currentReason={editingTarget.reason}
+            onClose={() => setEditingTarget(null)}
+            onSuccess={loadBlacklists}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/features/land/components/ResultModal.tsx
+++ b/src/features/land/components/ResultModal.tsx
@@ -36,9 +36,9 @@ export default function ResultModal({ isOpen, onClose, status, isLoading }: Resu
                                 <div className="animate-spin rounded-full h-10 w-10 border-4 border-purple-100 border-t-purple-600" />
                             </div>
                         ) : status ? (
-                            status.isPassed === true ? (
+                            status.passStatus === "APPROVED" ? (
                                 <PassedContent status={status} onClose={onClose} />
-                            ) : status.isPassed === false ? (
+                            ) : status.passStatus === "REJECTED" ? (
                                 <FailedContent status={status} onClose={onClose} />
                             ) : (
                                 <PendingContent status={status} onClose={onClose} />
@@ -77,7 +77,7 @@ function PassedContent({ status, onClose }: ContentProps) {
 
             {/* Details */}
             <div className="px-6 py-5 space-y-3 overflow-y-auto flex-1 min-h-0">
-                {status.classLevel && (
+                {status.classLevel && status.classLevel !== "미배정" && (
                     <InfoRow
                         label="배정 반"
                         value={status.classLevel}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -4,6 +4,10 @@ import type {
     ApplicantCreateRequestDto,
     ApplicantPassResponseDto,
     ApplicantResponseDto,
+    BlacklistAddRequestDto,
+    BlacklistDetailResponseDto,
+    BlacklistResponseDto,
+    BlacklistUpdateReasonRequestDto,
     LoginRequestDto,
     PageResponse,
     RecruitmentCreateRequestDto,
@@ -158,6 +162,67 @@ export const applicantService = {
     individualCreateMember: async (studentId: string): Promise<string> => {
         const response = await axiosInstance.post<ApiResponse<string>>(`/applicants/${studentId}`);
         return response.data.data;
+    }
+};
+
+export const blacklistService = {
+    add: async (data: BlacklistAddRequestDto): Promise<number> => {
+        const response = await axiosInstance.post<ApiResponse<number>>('/blacklists', data);
+        return response.data.data;
+    },
+    updateReason: async (id: number, data: BlacklistUpdateReasonRequestDto): Promise<number> => {
+        const response = await axiosInstance.patch<ApiResponse<number>>(`/blacklists/${id}`, data);
+        return response.data.data;
+    },
+    delete: async (id: number): Promise<number> => {
+        const response = await axiosInstance.delete<ApiResponse<number>>(`/blacklists/${id}`);
+        return response.data.data;
+    },
+    getDetail: async (id: number): Promise<BlacklistDetailResponseDto> => {
+        const response = await axiosInstance.get<ApiResponse<BlacklistDetailResponseDto>>(`/blacklists/${id}`);
+        return response.data.data;
+    },
+    getList: async (page: number = 0, size: number = 10): Promise<PageResponse<BlacklistResponseDto>> => {
+        const response = await axiosInstance.get<ApiResponse<PageResponse<BlacklistResponseDto> | BlacklistResponseDto[]>>('/blacklists', {
+            params: { page, size }
+        });
+        const data = response.data.data;
+
+        if (!data) {
+            return {
+                content: [],
+                pageNumber: 0,
+                pageSize: size,
+                totalElements: 0,
+                totalPages: 1,
+                last: true
+            };
+        }
+
+        if (Array.isArray(data)) {
+            return {
+                content: data,
+                pageNumber: 0,
+                pageSize: data.length,
+                totalElements: data.length,
+                totalPages: 1,
+                last: true
+            };
+        }
+
+        const rawData = data as unknown as Record<string, unknown>;
+        if (Array.isArray(rawData.contents)) {
+            return {
+                content: rawData.contents as BlacklistResponseDto[],
+                pageNumber: (rawData.page as number) ?? 0,
+                pageSize: (rawData.size as number) ?? size,
+                totalElements: (rawData.totalElements as number) ?? 0,
+                totalPages: (rawData.totalPages as number) ?? 1,
+                last: rawData.hasNext === false
+            };
+        }
+
+        return data as PageResponse<BlacklistResponseDto>;
     }
 };
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -37,13 +37,42 @@ export interface RecruitmentCreateRequestDto {
     endDateTime: string;   // ISO 8601
 }
 
-export interface RecruitmentUpdateRequestDto extends RecruitmentCreateRequestDto { }
+export type RecruitmentUpdateRequestDto = RecruitmentCreateRequestDto;
 
 export interface RecruitmentResponseDto {
     id: number;
     title: string;
     startDateTime: string;
     endDateTime: string;
+}
+
+// Blacklist
+export interface BlacklistAddRequestDto {
+    studentId: string;
+    reason: string;
+}
+
+export interface BlacklistUpdateReasonRequestDto {
+    reason: string;
+}
+
+export interface BlacklistResponseDto {
+    id: number;
+    studentId: string;
+    name: string;
+    department: string;
+    createdAt: string;
+}
+
+export interface BlacklistDetailResponseDto {
+    id: number;
+    studentId: string;
+    name: string;
+    email: string;
+    department: string;
+    phoneNumber: string;
+    reason: string;
+    createdAt: string;
 }
 
 // Applicants

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -99,6 +99,8 @@ export interface ApplicantCreateRequestDto {
     applyReason: string;
 }
 
+export type PassStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
+
 export interface ApplicantPassResponseDto {
     name: string;
     classLevel: string | null;
@@ -106,7 +108,7 @@ export interface ApplicantPassResponseDto {
     groupAccountNumber: string | null;
     recruitmentId: number;
     passedMessage: string | null;
-    isPassed: boolean | null;
+    passStatus: PassStatus;
 }
 
 export type ClassLevel = 'SEED' | 'BRANCH' | 'TREE';
@@ -120,7 +122,7 @@ export interface ApplicantResponseDto {
     bojId?: string; // Backend sends bojId
     mainLanguage?: MainLanguage;
     applyReason?: string; // Backend sends applyReason
-    isApprove: boolean | null;
+    passStatus: PassStatus;
     classLevel?: string | null;
     createdAt: string;
 


### PR DESCRIPTION
## 요약

- Close #41 
- 지원자 합격 여부 API 필드 변경(`isApprove`/`isPassed` Boolean ➔ `passStatus` Enum) 반영 및 신청 관리 페이지
  UI 디테일 개선, 블랙리스트 관리 페이지 디자인 작업을 진행했습니다.

## 변경 사항

### 1. API 변경 사항 반영 (`PassStatus` Enum 체계 전환)
    - **타입 정의 및 DTO 수정 (`services/types.ts`)**
      - `PassStatus` Enum 타입 정의 (`'PENDING' | 'APPROVED' | 'REJECTED'`)
      - `ApplicantPassResponseDto`, `ApplicantResponseDto` 내 기존 Boolean 필드(`isPassed`, `isApprove`)를
  `passStatus` 필드로 변경
    - **개인 합격 조회 모달 (`ResultModal.tsx`)**
      - `passStatus` 값 (`APPROVED`, `REJECTED`, `PENDING`)에 따른 모달 상태 분기 수정
      - 반 미배정 시 응답되는 `classLevel` 기본값(`"미배정"`) 예외 처리
    - **관리자 신청 관리 기능 (`ApplicationFilter.tsx`, `ApplicationTable.tsx`, `ApplicationListPage.tsx`,
  `ApplicationDetailModal.tsx`)**
      - 신청 목록 필터링, 테이블 상태 바지, 상세 모달 선택 옵션을 `PassStatus` Enum에 맞게 전환
      - 회원 승인 전환 API 호출 시 `APPROVED` 상태가 아닌 미승인 지원자에 대한 `409 CONFLICT` 에러 안내 메시지
  추가

    ### 2. UI 및 디자인 개편
    - **블랙리스트 관리 페이지 디자인 추가**
      - 블랙리스트 목록 조회, 신규 등록, 사유 수정 및 상세 보기 모달 UI 구현
    - **신청 관리 페이지 디자인 통일**
      - 신청 관리 테이블, 필터, 서브 네비게이션 레이아웃을 블랙리스트 페이지 디자인 시스템과 통일감 있게 정돈

## 스크린 샷

[ 기본 블랙리스트 관리 페이지 디자인 ]
<img width="1725" height="999" alt="image" src="https://github.com/user-attachments/assets/57bfebf3-ca03-4c7f-a18a-89deeb6c5cee" />

[ 블랙리스트 상세 정보 모달 디자인 ]
<img width="580" height="558" alt="image" src="https://github.com/user-attachments/assets/88f4f102-3c3d-4843-9e54-5f3b0db352e9" />

[ 블랙리스트 사유 수정 모달 디자인 ]
<img width="522" height="323" alt="image" src="https://github.com/user-attachments/assets/62886677-2115-405b-8ede-d9277829c13d" />

[ 블랙리스트 등록 모달 디자인 ]
<img width="529" height="441" alt="image" src="https://github.com/user-attachments/assets/e775643b-6a37-493b-b72d-4f131477dba8" />
