### PR TITLE
feat: 알림 시스템 도입 및 전역 alert/에러 핸들링 개선

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from "@/context/AuthContext";
 import Button from "@/components/ui/Button";
+import { toast } from "@/components/ui/toastStore";
 
 import { useState } from "react";
 import { AnimatePresence } from "framer-motion";
@@ -30,11 +31,12 @@ export default function Navbar() {
               key={item.label}
               href={item.href}
               className="text-[14px] font-medium text-neutral-500 hover:text-purple-600 transition-colors cursor-pointer"
-              onClick={item.href === "#" ? (e) => { e.preventDefault(); alert("아직 개발중입니다."); } : undefined}
+              onClick={item.href === "#" ? (e) => { e.preventDefault(); toast.info("아직 준비 중인 기능입니다."); } : undefined}
             >
               {item.label}
             </a>
           ))}
+
 
           {(user?.role === 'STAFF' || user?.role === 'NEST' || user?.role === 'SUPER' || user?.role === 'ADMIN') && (
             <a

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -3,7 +3,9 @@ import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { useAuth } from "@/context/AuthContext";
 import { applicantService } from "@/services/api";
-import type { ApplicantPassResponseDto } from "@/services/types";
+import type { ApplicantPassResponseDto, User } from "@/services/types";
+import { toast } from "@/components/ui/toastStore";
+import { getErrorMessage } from "@/utils/error";
 import ResultModal from "@/features/land/components/ResultModal";
 
 const LINK_STYLE =
@@ -30,6 +32,7 @@ export default function PageHeader() {
       setPassStatus(status);
     } catch (error) {
       console.error("Failed to fetch applicant status", error);
+      toast.error(getErrorMessage(error, "합격 여부를 조회하지 못했습니다."));
     } finally {
       setIsLoading(false);
     }
@@ -96,7 +99,7 @@ function DesktopNav({
   onCheckResult,
 }: {
   navLinks: { label: string; to: string }[];
-  user: any;
+  user: User | null;
   logout: () => void;
   onCheckResult: () => void;
 }) {
@@ -135,7 +138,7 @@ function MobileNav({
   onCheckResult,
   onToggleMenu,
 }: {
-  user: any;
+  user: User | null;
   logout: () => void;
   onCheckResult: () => void;
   onToggleMenu: () => void;
@@ -180,11 +183,12 @@ function CtaButton({
   onCheckResult,
   mobile,
 }: {
-  user: any;
+  user: User | null;
   onCheckResult: () => void;
   mobile?: boolean;
 }) {
   const px = mobile ? "px-4" : "px-5";
+
   const base = `${px} h-full flex items-center text-sm font-bold bg-black text-[#a855f7] hover:bg-black/85 transition-colors gap-2`;
 
   if (!user) {

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState, useCallback, type ReactNode, type ComponentType } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { CheckCircle2, AlertCircle, AlertTriangle, Info, X } from "lucide-react";
+import {
+  type ToastType,
+  type ToastItem,
+  toast,
+  toastManager,
+  ToastContext,
+} from "./toastStore";
+
+const TYPE_CONFIG: Record<
+  ToastType,
+  {
+    borderColor: string;
+    iconColor: string;
+    icon: ComponentType<{ size?: number; className?: string }>;
+    defaultTitle: string;
+  }
+> = {
+  success: {
+    borderColor: "border-l-emerald-500",
+    iconColor: "text-emerald-600",
+    icon: CheckCircle2,
+    defaultTitle: "성공",
+  },
+  error: {
+    borderColor: "border-l-rose-500",
+    iconColor: "text-rose-600",
+    icon: AlertCircle,
+    defaultTitle: "오류",
+  },
+  warning: {
+    borderColor: "border-l-amber-500",
+    iconColor: "text-amber-600",
+    icon: AlertTriangle,
+    defaultTitle: "경고",
+  },
+  info: {
+    borderColor: "border-l-purple-600",
+    iconColor: "text-purple-600",
+    icon: Info,
+    defaultTitle: "안내",
+  },
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  useEffect(() => {
+    const unsubscribe = toastManager.subscribe((items) => {
+      setToasts(items);
+    });
+    return unsubscribe;
+  }, []);
+
+  const handleDismiss = useCallback((id: string) => {
+    toastManager.dismiss(id);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      {/* Toast Container */}
+      <div
+        aria-live="assertive"
+        className="fixed top-4 right-4 z-[9999] flex flex-col gap-2.5 max-w-sm w-full pointer-events-none px-4 sm:px-0"
+      >
+        <AnimatePresence mode="sync">
+          {toasts.map((item) => {
+            const config = TYPE_CONFIG[item.type];
+            const IconComponent = config.icon;
+            const title = item.title ?? config.defaultTitle;
+
+            return (
+              <motion.div
+                key={item.id}
+                layout
+                initial={{ opacity: 0, y: -16, scale: 0.95 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, x: 24, scale: 0.95 }}
+                transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+                className={`pointer-events-auto bg-white border border-neutral-200 border-l-4 ${config.borderColor} shadow-xl overflow-hidden flex items-start p-4 gap-3`}
+              >
+                <div className={`shrink-0 mt-0.5 ${config.iconColor}`}>
+                  <IconComponent size={18} />
+                </div>
+
+                <div className="flex-1 min-w-0">
+                  <h4 className="text-xs font-black tracking-tight text-neutral-900 uppercase">
+                    {title}
+                  </h4>
+                  <p className="text-xs font-medium text-neutral-600 mt-1 leading-relaxed break-words whitespace-pre-line">
+                    {item.message}
+                  </p>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => handleDismiss(item.id)}
+                  className="shrink-0 p-1 -mr-1 -mt-1 text-neutral-400 hover:text-neutral-900 hover:bg-neutral-100 transition-colors"
+                  aria-label="닫기"
+                >
+                  <X size={14} />
+                </button>
+              </motion.div>
+            );
+          })}
+        </AnimatePresence>
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export default ToastProvider;

--- a/src/components/ui/toastStore.ts
+++ b/src/components/ui/toastStore.ts
@@ -1,0 +1,107 @@
+import { createContext, useContext } from "react";
+
+export type ToastType = "success" | "error" | "warning" | "info";
+
+export interface ToastOptions {
+  id?: string;
+  title?: string;
+  duration?: number;
+}
+
+export interface ToastItem {
+  id: string;
+  type: ToastType;
+  title?: string;
+  message: string;
+  duration: number;
+}
+
+export type ToastListener = (toasts: ToastItem[]) => void;
+
+// Global Toast State Manager for standalone toast.xxx() calls
+class ToastManager {
+  private toasts: ToastItem[] = [];
+  private listeners: Set<ToastListener> = new Set();
+  private maxToasts = 4;
+
+  subscribe(listener: ToastListener): () => void {
+    this.listeners.add(listener);
+    listener([...this.toasts]);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private notify() {
+    this.listeners.forEach((listener) => listener([...this.toasts]));
+  }
+
+  show(type: ToastType, message: string, options?: ToastOptions): string {
+    const id = options?.id || `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+    const defaultDuration = type === "error" || type === "warning" ? 5000 : 3500;
+    const duration = options?.duration ?? defaultDuration;
+
+    const newToast: ToastItem = {
+      id,
+      type,
+      title: options?.title,
+      message,
+      duration,
+    };
+
+    // Keep max 4 toasts
+    this.toasts = [newToast, ...this.toasts.filter((t) => t.id !== id)].slice(0, this.maxToasts);
+    this.notify();
+
+    if (duration > 0) {
+      setTimeout(() => {
+        this.dismiss(id);
+      }, duration);
+    }
+
+    return id;
+  }
+
+  dismiss(id?: string) {
+    if (id) {
+      this.toasts = this.toasts.filter((t) => t.id !== id);
+    } else {
+      this.toasts = [];
+    }
+    this.notify();
+  }
+}
+
+export const toastManager = new ToastManager();
+
+export const toast = {
+  success: (message: string, options?: ToastOptions | string) => {
+    const opts = typeof options === "string" ? { title: options } : options;
+    return toastManager.show("success", message, opts);
+  },
+  error: (message: string, options?: ToastOptions | string) => {
+    const opts = typeof options === "string" ? { title: options } : options;
+    return toastManager.show("error", message, opts);
+  },
+  warning: (message: string, options?: ToastOptions | string) => {
+    const opts = typeof options === "string" ? { title: options } : options;
+    return toastManager.show("warning", message, opts);
+  },
+  info: (message: string, options?: ToastOptions | string) => {
+    const opts = typeof options === "string" ? { title: options } : options;
+    return toastManager.show("info", message, opts);
+  },
+  dismiss: (id?: string) => {
+    toastManager.dismiss(id);
+  },
+};
+
+export interface ToastContextType {
+  toast: typeof toast;
+}
+
+export const ToastContext = createContext<ToastContextType>({ toast });
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/src/features/admin/components/ApplicationDetailModal.tsx
+++ b/src/features/admin/components/ApplicationDetailModal.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from "react";
 import { type ApplicantResponseDto, type PassStatus } from "@/services/types";
+import { toast } from "@/components/ui/toastStore";
+import { getErrorMessage } from "@/utils/error";
 import { motion } from "framer-motion";
 import { ChevronDown } from "lucide-react";
 
@@ -55,6 +57,7 @@ export default function ApplicationDetailModal({
         setSelectedStatus(fullData.passStatus || "PENDING");
       } catch (e) {
         console.error("Failed to fetch detail", e);
+        toast.error(getErrorMessage(e, "상세 정보를 불러오지 못했습니다."));
         setDetail((prev) => ({ ...prev, isLoading: false }));
       }
     };
@@ -75,13 +78,16 @@ export default function ApplicationDetailModal({
       if (selectedStatus !== detail.passStatus) {
         await onUpdateStatus(selectedStatus);
       }
+      toast.success("변경사항이 성공적으로 저장되었습니다.");
+      onClose();
     } catch (e) {
       console.error("Failed to save changes", e);
+      toast.error(getErrorMessage(e, "변경사항 저장 중 오류가 발생했습니다."));
     } finally {
       setIsSaving(false);
-      onClose();
     }
   };
+
 
   const statusLabel =
     detail.passStatus === "APPROVED" ? "합격" : detail.passStatus === "REJECTED" ? "불합격" : "대기중";

--- a/src/features/admin/components/BlacklistAddModal.tsx
+++ b/src/features/admin/components/BlacklistAddModal.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 import { X, ShieldAlert, Loader2 } from "lucide-react";
 import { blacklistService } from "@/services/api";
+import { toast } from "@/components/ui/toastStore";
+import { getErrorMessage } from "@/utils/error";
 
 interface Props {
   isOpen: boolean;
@@ -36,25 +38,21 @@ export default function BlacklistAddModal({ isOpen, onClose, onSuccess }: Props)
         studentId: studentId.trim(),
         reason: reason.trim(),
       });
-      alert("블랙리스트 대상자가 성공적으로 등록되었습니다.");
+      toast.success("블랙리스트 대상자가 성공적으로 등록되었습니다.");
       setStudentId("");
       setReason("");
       onSuccess();
       onClose();
     } catch (e: unknown) {
       console.error(e);
-      let msg = "등록 중 오류가 발생했습니다.";
-      if (e && typeof e === "object" && "response" in e) {
-        const res = (e as { response?: { data?: { message?: string } } }).response;
-        if (res?.data?.message) {
-          msg = res.data.message;
-        }
-      }
+      const msg = getErrorMessage(e, "등록 중 오류가 발생했습니다.");
       setErrorMessage(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
     }
   };
+
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">

--- a/src/features/admin/components/BlacklistDetailModal.tsx
+++ b/src/features/admin/components/BlacklistDetailModal.tsx
@@ -3,6 +3,8 @@ import { motion } from "framer-motion";
 import { X, ShieldAlert, Edit2, Trash2, Mail, Phone, Calendar, BookOpen, type LucideIcon } from "lucide-react";
 import { blacklistService } from "@/services/api";
 import type { BlacklistDetailResponseDto } from "@/services/types";
+import { toast } from "@/components/ui/toastStore";
+import { getErrorMessage } from "@/utils/error";
 
 interface Props {
   blacklistId: number;
@@ -29,11 +31,14 @@ export default function BlacklistDetailModal({
       setDetail(data);
     } catch (e: unknown) {
       console.error(e);
-      setError("상세 정보를 불러올 수 없습니다.");
+      const msg = getErrorMessage(e, "상세 정보를 불러올 수 없습니다.");
+      setError(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
     }
   }, [blacklistId]);
+
 
   useEffect(() => {
     loadDetail();

--- a/src/features/admin/components/BlacklistEditModal.tsx
+++ b/src/features/admin/components/BlacklistEditModal.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { X, Edit2, Loader2 } from "lucide-react";
 import { blacklistService } from "@/services/api";
+import { toast } from "@/components/ui/toastStore";
+import { getErrorMessage } from "@/utils/error";
 
 interface Props {
   isOpen: boolean;
@@ -42,16 +44,19 @@ export default function BlacklistEditModal({
       await blacklistService.updateReason(blacklistId, {
         reason: reason.trim(),
       });
-      alert("사유가 변경되었습니다.");
+      toast.success("사유가 성공적으로 변경되었습니다.");
       onSuccess();
       onClose();
     } catch (e: unknown) {
       console.error(e);
-      setError("사유 수정 중 오류가 발생했습니다.");
+      const msg = getErrorMessage(e, "사유 수정 중 오류가 발생했습니다.");
+      setError(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
     }
   };
+
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">

--- a/src/features/admin/pages/ApplicationListPage.tsx
+++ b/src/features/admin/pages/ApplicationListPage.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
 
 import { applicantService, recruitmentService } from "@/services/api";
 import type { ApplicantResponseDto, PassStatus } from "@/services/types";
+import { toast } from "@/components/ui/toastStore";
+import { getErrorMessage } from "@/utils/error";
 import { AnimatePresence } from "framer-motion";
 import { Loader2, Users } from "lucide-react";
 import AdminSubNav from "../components/AdminSubNav";
@@ -30,20 +32,14 @@ export default function ApplicationListPage() {
         return;
       }
       if (user.role === "USER" || user.role === "GUEST") {
-        alert("접근 권한이 없습니다.");
+        toast.warning("접근 권한이 없습니다.");
         navigate("/", { replace: true });
         return;
       }
     }
   }, [user, isAuthLoading, navigate]);
 
-  useEffect(() => {
-    if (user && !isAuthLoading && user.role !== "USER" && user.role !== "GUEST") {
-      loadApplications();
-    }
-  }, [user, isAuthLoading]);
-
-  const loadApplications = async () => {
+  const loadApplications = useCallback(async () => {
     setLoading(true);
     try {
       let recruitmentId = currentRecruitmentId;
@@ -58,12 +54,19 @@ export default function ApplicationListPage() {
         const data = await applicantService.getList(recruitmentId, 0, 100);
         setApplications(data?.content || []);
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error("Failed to load applications:", e);
+      toast.error(getErrorMessage(e, "지원자 목록을 불러오지 못했습니다."));
     } finally {
       setLoading(false);
     }
-  };
+  }, [currentRecruitmentId]);
+
+  useEffect(() => {
+    if (user && !isAuthLoading && user.role !== "USER" && user.role !== "GUEST") {
+      loadApplications();
+    }
+  }, [user, isAuthLoading, loadApplications]);
 
   const toggleStatus = async (app: ApplicantResponseDto, explicitStatus?: PassStatus) => {
     let targetStatus: PassStatus;
@@ -83,11 +86,14 @@ export default function ApplicationListPage() {
       }
       if (targetStatus === "APPROVED") {
         await applicantService.approve(app.studentId);
+        toast.success(`${app.name} 지원자가 합격 처리되었습니다.`);
       } else if (targetStatus === "REJECTED") {
         await applicantService.reject(app.studentId);
+        toast.info(`${app.name} 지원자가 불합격 처리되었습니다.`);
       }
     } catch (e) {
       console.error(e);
+      toast.error(getErrorMessage(e, "지원자 상태 변경에 실패했습니다."));
       loadApplications();
     }
   };
@@ -101,8 +107,10 @@ export default function ApplicationListPage() {
       if (selectedApp?.studentId === studentId) {
         setSelectedApp((prev) => (prev ? { ...prev, classLevel } : null));
       }
+      toast.success("반 배정이 변경되었습니다.");
     } catch (e) {
       console.error(e);
+      toast.error(getErrorMessage(e, "반 배정 변경에 실패했습니다."));
     }
   };
 
@@ -116,24 +124,15 @@ export default function ApplicationListPage() {
       await Promise.all(ids.map((id) => applicantService.approve(id)));
       await loadApplications();
       setSelectedIds(new Set());
-      alert("처리가 완료되었습니다.");
-    } catch (e: any) {
+      toast.success("선택한 지원자의 승인 및 계정 생성이 완료되었습니다.");
+    } catch (e: unknown) {
       console.error(e);
-      let errorMessage = "처리 중 오류가 발생했습니다.";
-      if (e.response) {
-        if (e.response.status === 409) {
-          errorMessage = "승인 실패 (409 CONFLICT): '합격(APPROVED)' 상태인 지원자만 계정 생성 승인이 가능합니다.";
-        } else {
-          errorMessage += `\n상태 코드: ${e.response.status}`;
-          if (e.response.data?.message) errorMessage += `\n메시지: ${e.response.data.message}`;
-          else if (e.response.data?.detail) errorMessage += `\n상세: ${e.response.data.detail}`;
-        }
-      }
-      alert(errorMessage);
+      toast.error(getErrorMessage(e, "일괄 처리에 실패했습니다."));
     } finally {
       setProcessing(false);
     }
   };
+
 
   const toggleSelection = (id: string) => {
     const newSet = new Set(selectedIds);

--- a/src/features/admin/pages/BlacklistPage.tsx
+++ b/src/features/admin/pages/BlacklistPage.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
 import { blacklistService } from "@/services/api";
 import type { BlacklistResponseDto, BlacklistDetailResponseDto } from "@/services/types";
+import { toast } from "@/components/ui/toastStore";
+import { getErrorMessage } from "@/utils/error";
 import { AnimatePresence } from "framer-motion";
 import { Plus, ShieldAlert, ChevronLeft, ChevronRight } from "lucide-react";
 import AdminSubNav from "../components/AdminSubNav";
@@ -36,6 +38,7 @@ export default function BlacklistPage() {
       setTotalElements(data?.totalElements || (data?.content ? data.content.length : 0));
     } catch (e) {
       console.error("Failed to load blacklists:", e);
+      toast.error(getErrorMessage(e, "블랙리스트 목록을 불러오지 못했습니다."));
     } finally {
       setLoading(false);
     }
@@ -48,7 +51,7 @@ export default function BlacklistPage() {
         return;
       }
       if (user.role === "USER" || user.role === "GUEST") {
-        alert("접근 권한이 없습니다.");
+        toast.warning("접근 권한이 없습니다.");
         navigate("/", { replace: true });
         return;
       }
@@ -68,16 +71,17 @@ export default function BlacklistPage() {
     }
     try {
       await blacklistService.delete(item.id);
-      alert("블랙리스트에서 해제되었습니다.");
+      toast.success("블랙리스트에서 정상적으로 해제되었습니다.");
       if (selectedDetailId === item.id) {
         setSelectedDetailId(null);
       }
       loadBlacklists();
     } catch (e) {
       console.error("Failed to delete blacklist:", e);
-      alert("해제 처리 중 오류가 발생했습니다.");
+      toast.error(getErrorMessage(e, "블랙리스트 해제 처리 중 오류가 발생했습니다."));
     }
   };
+
 
   return (
     <div className="min-h-screen bg-neutral-100 text-black">

--- a/src/features/auth/login/pages/LoginPage.tsx
+++ b/src/features/auth/login/pages/LoginPage.tsx
@@ -3,6 +3,8 @@ import { useNavigate, Link } from "react-router-dom";
 import { motion } from "framer-motion";
 import { Eye, EyeOff } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
+import { toast } from "@/components/ui/toastStore";
+import { getErrorMessage } from "@/utils/error";
 
 export default function LoginPage() {
   const [studentId, setStudentId] = useState("");
@@ -19,14 +21,26 @@ export default function LoginPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!studentId.trim()) {
+      setError("학번을 입력해주세요.");
+      return;
+    }
+    if (!password.trim()) {
+      setError("비밀번호를 입력해주세요.");
+      return;
+    }
     setError("");
     try {
-      await login(studentId, password);
+      await login(studentId.trim(), password);
+      toast.success("로그인되었습니다.");
       navigate("/");
-    } catch (err: any) {
-      setError(err.toString());
+    } catch (err: unknown) {
+      const msg = getErrorMessage(err, "학번 또는 비밀번호가 올바르지 않습니다.");
+      setError(msg);
+      toast.error(msg);
     }
   };
+
 
   return (
     <div className="h-[calc(100dvh-3.5rem)] overflow-hidden flex flex-col bg-neutral-100 text-black">

--- a/src/features/auth/login/pages/LoginPage.tsx
+++ b/src/features/auth/login/pages/LoginPage.tsx
@@ -32,7 +32,6 @@ export default function LoginPage() {
     setError("");
     try {
       await login(studentId.trim(), password);
-      toast.success("로그인되었습니다.");
       navigate("/");
     } catch (err: unknown) {
       const msg = getErrorMessage(err, "학번 또는 비밀번호가 올바르지 않습니다.");
@@ -40,6 +39,7 @@ export default function LoginPage() {
       toast.error(msg);
     }
   };
+
 
 
   return (

--- a/src/features/auth/signup/pages/SignupPage.tsx
+++ b/src/features/auth/signup/pages/SignupPage.tsx
@@ -3,8 +3,22 @@ import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { applicantService, recruitmentService } from "@/services/api";
 import type { MainLanguage } from "@/services/types";
+import { toast } from "@/components/ui/toastStore";
+import { getErrorMessage } from "@/utils/error";
 import SignupForm from "../components/SignupForm";
 import FaqAccordion from "../components/FaqAccordion";
+
+interface SignupFormData {
+  email: string;
+  password: string;
+  name: string;
+  department: string;
+  studentId: string;
+  phone: string;
+  baekjoon: string;
+  language: string;
+  motivation?: string;
+}
 
 export default function SignupPage() {
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -15,16 +29,17 @@ export default function SignupPage() {
     return () => { document.documentElement.style.overflow = ""; };
   }, []);
 
-  const handleSubmit = async (formData: any) => {
+  const handleSubmit = async (formData: SignupFormData) => {
+
     try {
       const recruitments = await recruitmentService.getAll();
       if (!recruitments || recruitments.length === 0) {
-        alert("현재 진행 중인 모집이 없습니다.");
+        toast.warning("현재 진행 중인 모집이 없습니다.");
         return;
       }
       const lastRecruitment = recruitments[recruitments.length - 1];
       if (!lastRecruitment) {
-        alert("모집 정보를 불러오는 중 오류가 발생했습니다.");
+        toast.error("모집 정보를 불러오는 중 오류가 발생했습니다.");
         return;
       }
 
@@ -37,14 +52,17 @@ export default function SignupPage() {
         phoneNumber: formData.phone,
         bojId: formData.baekjoon,
         mainLanguage: formData.language as MainLanguage,
-        applyReason: formData.motivation,
+        applyReason: formData.motivation || "",
         recruitmentId: lastRecruitment.id,
       });
+
+      toast.success("입단 신청이 성공적으로 접수되었습니다.");
       setIsSubmitted(true);
-    } catch (err: any) {
-      alert("신청 제출 중 오류가 발생했습니다: " + (err.response?.data?.message || err.message));
+    } catch (err: unknown) {
+      toast.error(getErrorMessage(err, "신청 제출 중 오류가 발생했습니다."));
     }
   };
+
 
   return (
     <div className="h-[calc(100dvh-3.5rem)] overflow-hidden flex flex-col bg-neutral-100 text-black">

--- a/src/features/land/components/RecruitmentInfoModal.tsx
+++ b/src/features/land/components/RecruitmentInfoModal.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { recruitmentService } from "@/services/api";
 import type { RecruitmentResponseDto } from "@/services/types";
+import { toast } from "@/components/ui/toastStore";
+import { getErrorMessage } from "@/utils/error";
 
 interface RecruitmentInfoModalProps {
   onClose: () => void;
@@ -24,10 +26,12 @@ export default function RecruitmentInfoModal({ onClose }: RecruitmentInfoModalPr
       setRecruitments(sorted);
     } catch (e) {
       console.error("Failed to load recruitments:", e);
+      toast.error(getErrorMessage(e, "모집 일정을 불러오지 못했습니다."));
     } finally {
       setLoading(false);
     }
   };
+
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,15 +4,16 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 import { AuthProvider } from '@/context/AuthContext';
-
-
+import { ToastProvider } from '@/components/ui/Toast';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <ToastProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ToastProvider>
     </AuthProvider>
   </StrictMode>
-);
+);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,73 @@
+import axios, { AxiosError } from "axios";
+
+/**
+ * HTTP 상태 코드별 기본 사용자 친화적 메시지 매핑
+ */
+const HTTP_STATUS_MESSAGES: Record<number, string> = {
+  400: "요청 데이터가 올바르지 않습니다.",
+  401: "로그인이 필요하거나 인증이 만료되었습니다.",
+  403: "해당 작업을 수행할 권한이 없습니다.",
+  404: "요청하신 대상을 찾을 수 없습니다.",
+  409: "요청이 현재 서버 상태와 충돌하여 처리할 수 없습니다.",
+  500: "서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+  502: "서버 게이트웨이 오류가 발생했습니다.",
+  503: "현재 서버 점검 중이거나 일시적으로 서비스를 이용할 수 없습니다.",
+  504: "서버 응답 시간이 초과되었습니다.",
+};
+
+/**
+ * 다양한 형태의 에러 객체(AxiosError, Error, string 등)로부터
+ * 사용자에게 노출하기 적합한 한국어 메시지를 추출합니다.
+ *
+ * 우선순위:
+ * 1. 백엔드 응답 본문의 메시지 (response.data.message 또는 detail)
+ * 2. 네트워크 단절 / 타임아웃 오류 안내
+ * 3. HTTP 상태 코드별 매핑 메시지
+ * 4. 제공된 fallback 메시지 또는 기본 오류 메시지
+ */
+export function getErrorMessage(error: unknown, fallbackMessage = "요청 처리 중 오류가 발생했습니다."): string {
+  if (!error) {
+    return fallbackMessage;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (axios.isAxiosError(error)) {
+    const axiosError = error as AxiosError<{ message?: string; detail?: string; error?: string }>;
+
+    // 1. 백엔드에서 전달된 커스텀 에러 메시지
+    const backendMessage =
+      axiosError.response?.data?.message ||
+      axiosError.response?.data?.detail ||
+      axiosError.response?.data?.error;
+
+    if (backendMessage && typeof backendMessage === "string" && backendMessage.trim()) {
+      return backendMessage;
+    }
+
+    // 2. 네트워크 오류 / 타임아웃
+    if (axiosError.code === "ERR_NETWORK" || axiosError.message === "Network Error") {
+      return "서버와 연결할 수 없습니다. 네트워크 연결 상태를 확인해주세요.";
+    }
+    if (axiosError.code === "ECONNABORTED" || axiosError.message.includes("timeout")) {
+      return "서버 응답 시간이 초과되었습니다. 다시 시도해주세요.";
+    }
+
+    // 3. HTTP 상태 코드 기반 메시지
+    const status = axiosError.response?.status;
+    if (status && HTTP_STATUS_MESSAGES[status]) {
+      return HTTP_STATUS_MESSAGES[status];
+    }
+  }
+
+  if (error instanceof Error && error.message) {
+    // raw axios 메시지나 technical 문자열 필터링
+    if (!error.message.startsWith("AxiosError") && !error.message.startsWith("Request failed with status code")) {
+      return error.message;
+    }
+  }
+
+  return fallbackMessage;
+}


### PR DESCRIPTION
## 요약

- Close #51 
- 브라우저 기본 `alert()`과 raw 에러 노출을 제거하고, 사이트 디자인 시스템에 맞춘 전역 Toast 알림 및 에러
  파싱 시스템을 구축하여 사용자 피드백 UX를 개선했습니다.

    ## 변경 사항

    - `framer-motion` 기반의 미니멀/보더 스타일 커스텀 Toast 컴포넌트(`ToastProvider`, `toastStore`) 구현
    - 백엔드 에러 메시지, HTTP 상태 코드, 네트워크 단절을 처리하는 공통 에러 파서 유틸(`getErrorMessage`) 추가
    - `App` 최상단에 `ToastProvider`를 래핑하여 전역에서 `toast.success/error/warning/info` 호출 가능하도록 환경
  구성
    - 로그인 페이지에서 `err.toString()` 노출 제거 및 실패/성공 Toast 피드백 적용
    - 입단 신청 페이지에서 모집 공고 검증 및 제출 실패/성공 시 `alert`를 Toast로 전면 교체
    - 신청 관리 페이지에서 권한 체크, 합격/불합격 토글, 일괄 승인 시 Toast 알림 적용
    - 지원자 상세 모달에서 저장 실패 시 모달 강제 닫힘 방지 및 에러 Toast 노출
    - 블랙리스트 관리 페이지 및 모달 3종(등록/수정/해제)의 `alert`를 Toast 피드백으로 전면 교체
    - 메인 헤더 및 공통 네비게이션의 합격 조회 및 모집 일정 로드 실패 시 에러 Toast 처리

    ## 주의 사항

    - 컴포넌트 내부뿐만 아니라 일반 비동기 함수나 이벤트 핸들러에서도 `import { toast } from
  '@/components/ui/toastStore'`를 통해 즉시 알림을 띄울 수 있습니다.
    - API 에러 발생 시 `toast.error(getErrorMessage(error, "기본 안내 문구"))` 패턴을 사용하여 백엔드 에러
  메시지를 우선 노출하도록 통일했습니다.
## 스크린 샷
[ 오류 발생 시 알림 디자인 ]
<img width="390" height="88" alt="image" src="https://github.com/user-attachments/assets/7c0afbfd-e438-4980-9df5-d5d60084f727" />

[ 성공 시 알림 디자인 ]
<img width="390" height="81" alt="dyn-adaaa3731ef2997086e9f6b9eabc585b" src="https://github.com/user-attachments/assets/39b3f86e-59e6-46ff-bec7-13bc231bdd72" />

